### PR TITLE
fix(create-component): ignore exception icons

### DIFF
--- a/scripts/constants.ts
+++ b/scripts/constants.ts
@@ -10,3 +10,5 @@ export const ICON_POSTFIX = 'Icon';
 export const ENCODING = 'utf-8';
 
 export const MOBILE_PREFIXES = ['ios', 'android'];
+
+export const IGNORE_ICONS = ['tshirt'];

--- a/scripts/create-component.ts
+++ b/scripts/create-component.ts
@@ -7,7 +7,7 @@ import Svgo from 'svgo';
 
 import { iconTemplate } from '../templates/icon.template';
 import { SVG_EXT } from './generate';
-import { ENCODING, MOBILE_PREFIXES } from './constants';
+import { ENCODING, IGNORE_ICONS, MOBILE_PREFIXES } from './constants';
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
@@ -110,6 +110,8 @@ export async function createComponent(
     if (MOBILE_PREFIXES.includes(packageName)) {
         [name, size, color] = iconParams;
     }
+
+    if (IGNORE_ICONS.includes(name)) return;
 
     let componentName = `${name}_${size}${color ? `_${color}` : ``}`;
 


### PR DESCRIPTION
иконки с одинаковыми импортами (разница только в регистре ) падают, поэтому решили создать массив исключений, чтобы в ui-priminives могли быть оба варианта , а в icons оставалась только иконка с корректным названием 
